### PR TITLE
fix: allow unstorage drivers other than 'memory' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Here's what the full _default_ module configuration looks like:
 ```
 
 ```
-### Using a different storage driver
+#### Using a different storage driver
 
 You can use any stroage driver supported by unstorage. For example, this will use the redis driver instead of the default memory driver.
 ```ts

--- a/README.md
+++ b/README.md
@@ -9,69 +9,60 @@
 [![Follow us on Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label)](https://twitter.com/sidebase_io)
 [![Join our Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.gg/9MUHR8WT9B)
 
-> Nuxt session middleware to get a persistent session per app user, e.g., to
-> store data across multiple requests. The nuxt session module provides the
-> `useSession()` composable out of the box and sets up API endpoints to interact
-> with your session to make working with sessions feel like a breeze.
+> Nuxt session middleware to get a persistent session per app user, e.g., to store data across multiple requests. The nuxt session module provides the `useSession()` composable out of the box and sets up API endpoints to interact with your session to make working with sessions feel like a breeze.
 
 ## Quick start
 
 1. Install the package:
-   ```bash
-   npm i -D @sidebase/nuxt-session
-   ```
+    ```bash
+    npm i -D @sidebase/nuxt-session
+    ```
 2. Add the package to your `nuxt.config.ts`:
-   ```bash
-   export default defineNuxtConfig({
-     modules: ['@sidebase/nuxt-session'],
-   })
-   ```
-3. Done! Each client will now have a unique session you can access on the
-   server- and client side:
-   - client-side (from any `.vue` file):
-     ```ts
-     const { session, refresh, update, reset } = await useSession();
+    ```bash
+    export default defineNuxtConfig({
+      modules: ['@sidebase/nuxt-session'],
+    })
+    ```
+3. Done! Each client will now have a unique session you can access on the server- and client side:
+    - client-side (from any `.vue` file):
+        ```ts
+        const { session, refresh, update, reset } = await useSession()
 
-     // Reactive session object that updates after methods calls below
-     session.value;
+        // Reactive session object that updates after methods calls below
+        session.value
 
-     // Refresh the session
-     await refresh();
+        // Refresh the session
+        await refresh()
 
-     // Update the session with arbitrary data
-     await update({ test: 123 });
+        // Update the session with arbitrary data
+        await update({ test: 123 })
 
-     // Get a new session, all data will be lost, the session id and creation time will change
-     await reset();
-     ```
-   - server-side (e.g., from `server/api` files):
-     ```ts
-     import { eventHandler } from "h3";
+        // Get a new session, all data will be lost, the session id and creation time will change
+        await reset()
+        ```
+    - server-side (e.g., from `server/api` files):
+        ```ts
+        import { eventHandler } from 'h3'
 
-     // Return all session data to the frontend
-     export default eventHandler((event) => event.context.session);
-     ```
+        // Return all session data to the frontend
+        export default eventHandler(event => event.context.session)
+        ```
 
-The `nuxt-session` library provide many helpers to interact with the session
-from the client- and server-side For more documentation and examples look at the
-[documentation](#documentation)
+The `nuxt-session` library provide many helpers to interact with the session from the client- and server-side For more documentation and examples look at the [documentation](#documentation)
 
 ## Features
 
 - ✔️ Persistent sessions across requests using cookies
 - ✔️ `useSession` composable for client side session-interaction
 - ✔️ Configurable session endpoints out of the box:
-  - `GET /api/session`: Get the current session
-  - `DELETE /api/session`: Delete the current session
-  - `POST /api/session`: Overwrite the current session data
-  - `PATCH /api/session`: Add to the current session data
-- ✔️ Storage via [unjs/unstorage](https://github.com/unjs/unstorage) - use
-  memory, redis, fs, cloudflare-kv, ... to store your session data
+    - `GET /api/session`: Get the current session
+    - `DELETE /api/session`: Delete the current session
+    - `POST /api/session`: Overwrite the current session data
+    - `PATCH /api/session`: Add to the current session data
+- ✔️ Storage via [unjs/unstorage](https://github.com/unjs/unstorage) - use memory, redis, fs, cloudflare-kv, ... to store your session data
 - ✔️ Automatic session and storage cleanup on expiry
 
-Use the module-playground (see playground below) to play around with the module.
-Read the [documentation](#documentation) if you want to learn about the library
-without starting your local environment.
+Use the module-playground (see playground below) to play around with the module. Read the [documentation](#documentation) if you want to learn about the library without starting your local environment.
 
 ## Playground
 
@@ -79,7 +70,6 @@ An example page making use of `nuxt-session`:
 ![nuxt session counter example](./.github/session-example.png)
 
 See the playground to interactively use this:
-
 ```sh
 > git clone https://github.com/sidebase/nuxt-session
 
@@ -96,54 +86,34 @@ See the playground to interactively use this:
 
 ## Documentation
 
-First of all: Try out the playground if you want to test-drive this package and
-learn how to use it. You can also have a look
-[at the playground code](./playground/app.vue) to see how to use `nuxt-session`
-in your app.
+First of all: Try out the playground if you want to test-drive this package and learn how to use it. You can also have a look [at the playground code](./playground/app.vue) to see how to use `nuxt-session` in your app.
 
-The `nuxt-session` maintains sessions: Persistent data across different requests
-by the same client (or: "user"). To maintain these sessions, `nuxt-session` sets
-a cookie with a unique client id for the currently connected client. Then after
-the cookie is set, the client will be uniquely identifiable by the server as
-long as:
-
+The `nuxt-session` maintains sessions: Persistent data across different requests by the same client (or: "user"). To maintain these sessions, `nuxt-session` sets a cookie with a unique client id for the currently connected client. Then after the cookie is set, the client will be uniquely identifiable by the server as long as:
 - the client sends this cookie on all subsequent requests,
-- the clients stay is shorter than the maximum session duration (default: 10
-  minutes, can be infinite in theory),
+- the clients stay is shorter than the maximum session duration (default: 10 minutes, can be infinite in theory),
 - the server does not loose it's data (e.g., due to a broken hard-drive)
 
 We call this "stay" that lasts as long as the above criteria are met a session.
 
 Below we describe:
-
 1. [Session data](#session-data)
-   - [Client-side access](#client-side-access)
-   - [Server-side access](#server-side-access)
+    - [Client-side access](#client-side-access)
+    - [Server-side access](#server-side-access)
 2. [How to configure session-storage](#storage-backends)
 3. [Configuration](#configuration)
 4. [Security](#security)
 
 ### Session Data
 
-The session that `nuxt-session` maintains for you also allows you to store
-arbitrary data in a storage across requests for the entire duration of the
-session. `nuxt-session` makes this data available to you in different ways,
-depending on whether you are on the client side (e.g., `.vue` components that
-are seen by your users) or on the server-side (e.g., inside an endpoint in the
-`server/api/` directory).
+The session that `nuxt-session` maintains for you also allows you to store arbitrary data in a storage across requests for the entire duration of the session. `nuxt-session` makes this data available to you in different ways, depending on whether you are on the client side (e.g., `.vue` components that are seen by your users) or on the server-side (e.g., inside an endpoint in the `server/api/` directory).
 
-Reading session data is generally safe on both the client- and server-side,
-unless it contains anything you don't want your users to see.
+Reading session data is generally safe on both the client- and server-side, unless it contains anything you don't want your users to see.
 
-Allowing alteration of session-data with arbitrary data provided by the client
-(e.g., your user) should be treated carefully, but can be safely done if you
-don't care about your users polluting sessions, have authentication and
-authorization or are generally not concerned about the security of your app.
+Allowing alteration of session-data with arbitrary data provided by the client (e.g., your user) should be treated carefully, but can be safely done if you don't care about your users polluting sessions, have authentication and authorization or are generally not concerned about the security of your app.
 
 #### Client Side Access
 
 On the client-side you can use the session like this:
-
 ```ts
 const {
   session,
@@ -151,140 +121,89 @@ const {
   remove,
   reset,
   update,
-  overwrite,
-} = await useSession();
+  overwrite
+} = await useSession()
 
 // The session itself, a ref that automatically updates when you use the other methods below
-session.value;
+session.value
 
 // Refresh the session, e.g., after you've changed the session on the server side OR when you don't have an active session at the moment
-await refresh();
+await refresh()
 
 // Delete the current session without getting a new one. Note that the next request will automatically get a new session
-await remove();
+await remove()
 
 // Reset the session: Under the hood this calls `remove` and then `refresh`
-await reset();
+await reset()
 
 // Update the current session with arbitrary data, this data is merged into the current session with the spread-syntax, so existing data remains (unless you provide new data with the same key!)
-await update({ "hello": "session", "test": 1234, "userLikesCookies": true });
+await update({ "hello": "session", "test": 1234, "userLikesCookies": true })
 
 // Overwrite
-await overwrite({
-  "test":
-    "This replaces all current data of the session without overwriting the current session itself",
-});
+await overwrite({ "test": "This replaces all current data of the session without overwriting the current session itself" })
 ```
 
-Per default all of the above is enabled. Read on if you want to learn how to
-configure and disable some of the above functionalities and their respective
-endpoints, e.g., to secure your application.
+Per default all of the above is enabled. Read on if you want to learn how to configure and disable some of the above functionalities and their respective endpoints, e.g., to secure your application.
 
-You can configure what endpoints and utilities `nuxt-session` adds for
-client-side use using the module configuration. The API is fully enabled per
-default. If you want to turn off the whole `nuxt-session` API you can set
-`session: { api: { isEnabled: false } }` in the module config in your
-`nuxt.config.ts`. If you want to keep the api enabled but allow just certain
-operation by the client-side, you can restrict the HTTP methods that should be
-allowed. E.g., `session: { api: { methods: ['get'] } }` would:
+You can configure what endpoints and utilities `nuxt-session` adds for client-side use using the module configuration. The API is fully enabled per default. If you want to turn off the whole `nuxt-session` API you can set `session: { api: { isEnabled: false } }` in the module config in your `nuxt.config.ts`. If you want to keep the api enabled but allow just certain operation by the client-side, you can restrict the HTTP methods that should be allowed. E.g., `session: { api: { methods: ['get'] } }` would:
+- add only one endpoint that allows reading the current session data (per default: `GET /api/session`)
+- enable only the `session` and `refresh` properties of the `useSession` composable
 
-- add only one endpoint that allows reading the current session data (per
-  default: `GET /api/session`)
-- enable only the `session` and `refresh` properties of the `useSession`
-  composable
+After this, calling the `reset()` or `update()` functions from above would result in an error that the methods are not supported and the api endpoints would not be added to your nuxt-app. This way:
+- you cannot accidentaly call a composable-method during development and it later does not work in production,
+- if somebody tried to manually access the endpoints they would not succeed as the endpoint does not exist
 
-After this, calling the `reset()` or `update()` functions from above would
-result in an error that the methods are not supported and the api endpoints
-would not be added to your nuxt-app. This way:
-
-- you cannot accidentaly call a composable-method during development and it
-  later does not work in production,
-- if somebody tried to manually access the endpoints they would not succeed as
-  the endpoint does not exist
-
-For all configuration options check out
-[the configuration section](#configuration).
+For all configuration options check out [the configuration section](#configuration).
 
 ##### Advanced Client-Side Usage
 
-The methods that `nuxt-session` expose are `useFetch` calls under the hood. For
-advanced use, debugging and error handling their result is directly exposed. So
-when you use one of them, you can destructure just like with
-[nuxt useFetch](https://v3.nuxtjs.org/api/composables/use-fetch#usefetch):
-
+The methods that `nuxt-session` expose are `useFetch` calls under the hood. For advanced use, debugging and error handling their result is directly exposed. So when you use one of them, you can destructure just like with [nuxt useFetch](https://v3.nuxtjs.org/api/composables/use-fetch#usefetch):
 ```ts
-const { data, pending, error, refresh } = await update({
-  "hello": "session",
-  "test": 1234,
-  "userLikesCookies": true,
-});
+const { data, pending, error, refresh } = await update({ "hello": "session", "test": 1234, "userLikesCookies": true })
 
 // ... do something with the above reactive useFetch properties
 ```
 
 #### Server Side Access
 
-`nuxt-session` makes the data of the current session available to all endpoints
-and middlewares as part of the `event` that is passed into the endpoints and
-middlewares at `event.context.session`. For example
-[here's](https://github.com/sidebase/nuxt-session/blob/main/playground/server/api/count.get.ts)
-how you can implement a server-side request counting endpoint that stores how
-many requests to this endpoint where performed by that specific session:
-
+`nuxt-session` makes the data of the current session available to all endpoints and middlewares as part of the `event` that is passed into the endpoints and middlewares at `event.context.session`. For example [here's](https://github.com/sidebase/nuxt-session/blob/main/playground/server/api/count.get.ts) how you can implement a server-side request counting endpoint that stores how many requests to this endpoint where performed by that specific session:
 ```ts
 // File: `playground/server/api/count.get.ts`
 export default eventHandler((event) => {
   // Get the current count or set to 0 if this is the first request
-  const currentCount = event.context.session.count || 0;
+  const currentCount = event.context.session.count || 0
 
   // Increase the count (nuxt-session will persist all changes made to `event.context.session` after the return)
-  event.context.session.count = currentCount + 1;
+  event.context.session.count = currentCount + 1
 
   // Return the count
-  return event.context.session.count;
-});
+  return event.context.session.count
+})
 ```
 
-All changes made to the `event.context.session` are automatically stored for
-subsequent requests by `nuxt-session`. So the count is set to `0` on the first
-request and then increases by `1` on every subsequent request.
+All changes made to the `event.context.session` are automatically stored for subsequent requests by `nuxt-session`. So the count is set to `0` on the first request and then increases by `1` on every subsequent request.
 
 The server-side session also contains it's own meta-data of the form:
-
 ```ts
 declare interface Session {
-  id: string;
-  createdAt: Date;
+  id: string
+  createdAt: Date
 }
 ```
 
-In theory you can manipulate this data on the server side if you want to. If you
-do this, the session will likely become invalid in the process, so proceed at
-your own risk!
+In theory you can manipulate this data on the server side if you want to. If you do this, the session will likely become invalid in the process, so proceed at your own risk!
 
 ### Storage Backends
 
-`nuxt-session` allows you to use different storage backends. A storage backend
-is something like your server memory, a redis database, the file-system of your
-server, ... Supporting these backend is possible by using
-[unjs/unstorage](https://github.com/unjs/unstorage) for storage management. This
-library connects to the different backends it supports with a unified interface.
+`nuxt-session` allows you to use different storage backends. A storage backend is something like your server memory, a redis database, the file-system of your server, ... Supporting these backend is possible by using [unjs/unstorage](https://github.com/unjs/unstorage) for storage management. This library connects to the different backends it supports with a unified interface.
 
-You can configure the storage backend using the `session.session.storageOptions`
-configuration option of the `nuxt-session` module. By default `memory` is used
-to store the sessions. This has some advantages like speed and easy setup, but
-some disadvantages like missing persistency (if your server crashes, the
-sessions are gone!) and possible exploits like setting millions of sessions
-trying to exhaust your server-memory or saving large amounts of data into the
-session that your server cannot handle.
+You can configure the storage backend using the `session.session.storageOptions` configuration option of the `nuxt-session` module. By default `memory` is used to store the sessions. This has some advantages like speed and easy setup, but some disadvantages like missing persistency (if your server crashes, the sessions are gone!) and possible exploits like setting millions of sessions trying to exhaust your server-memory or saving large amounts of data into the session that your server cannot handle.
 
-Check out here what storage backends are supported and how to configure them:
-https://github.com/unjs/unstorage#drivers
+Check out here what storage backends are supported and how to configure them: https://github.com/unjs/unstorage#drivers
 
 ### Configuration
 
 Here's what the full _default_ module configuration looks like:
-
 ```ts
 {
   // Module is enabled
@@ -319,11 +238,10 @@ Here's what the full _default_ module configuration looks like:
 }
 ```
 
+```
 ### Using a different storage driver
 
-You can use any stroage driver supported by unstorage. For example, this will
-use the redis driver instead of the default memory driver.
-
+You can use any stroage driver supported by unstorage. For example, this will use the redis driver instead of the default memory driver.
 ```ts
 //nuxt.config.ts
 {
@@ -339,82 +257,57 @@ use the redis driver instead of the default memory driver.
         }
     }
 }
+
 ```
 
 ### Security
 
-This section mostly contains a list of possible security problems and how to
-mitigate (some) of them. Note that the below flaws exist with many libraries and
-frameworks we use in our day-to-day when building and working with APIs. E.g.,
-your vanilla-nuxt-app is not safe of some of them like the client sending
-malicious data. Missing in the below list are estimates of how likely it is that
-one of the list-items may occur and what impact it will have on your app. This
-is because that heavily depends on:
+This section mostly contains a list of possible security problems and how to mitigate (some) of them. Note that the below flaws exist with many libraries and frameworks we use in our day-to-day when building and working with APIs. E.g., your vanilla-nuxt-app is not safe of some of them like the client sending malicious data. Missing in the below list are estimates of how likely it is that one of the list-items may occur and what impact it will have on your app. This is because that heavily depends on:
+- your app: Are you building a fun project? A proof of concept? The next fort-nox money management app?
+- your environment: Building a freely available app for fun? Have authentication in front of your app and trust all users that successfully authenticated? Superb! Don't trust anyone? Then please be extra-careful when using this library and when building you backend in general
 
-- your app: Are you building a fun project? A proof of concept? The next
-  fort-nox money management app?
-- your environment: Building a freely available app for fun? Have authentication
-  in front of your app and trust all users that successfully authenticated?
-  Superb! Don't trust anyone? Then please be extra-careful when using this
-  library and when building you backend in general
-
-Without further ado, here's some attack cases you can consider and take action
-against. Neither the attack vectors, the problems or the mitigations are
-exhaustive:
-
+Without further ado, here's some attack cases you can consider and take action against. Neither the attack vectors, the problems or the mitigations are exhaustive:
 1. sending arbitrary data
-   - problems: Denial-of-Service by server-ressource exhaustion (bandwidth, cpu,
-     memory), arbitrary code execution (if you parse the data), ...
-   - possible mitigations:
-     - disable api-access to session data (`api.isEnabled: false`) or restrict
-       it to only reading (`api: { methods: ['get'] }`)
-     - parse & validate data securely on the server side before storing it into
-       the session, e.g., using [zod](https://github.com/colinhacks/zod)
-     - we at some point implement some settings for this (e.g., max session
-       amount, size, ...)
+    - problems: Denial-of-Service by server-ressource exhaustion (bandwidth, cpu, memory), arbitrary code execution (if you parse the data), ...
+    - possible mitigations:
+        - disable api-access to session data (`api.isEnabled: false`) or restrict it to only reading (`api: { methods: ['get'] }`)
+        - parse & validate data securely on the server side before storing it into the session, e.g., using [zod](https://github.com/colinhacks/zod)
+        - we at some point implement some settings for this (e.g., max session amount, size, ...)
 2. creation arbitrarily many sessions
-   - problems: Denial-of-Service by server-ressource exhaustion (bandwidth, cpu,
-     memory)
-   - possible mitigations:
-     - add authentication and possibly authorization to your app
-     - use `redis` as a storage backend and set data to expire automatically
+    - problems: Denial-of-Service by server-ressource exhaustion (bandwidth, cpu, memory)
+    - possible mitigations:
+        - add authentication and possibly authorization to your app
+        - use `redis` as a storage backend and set data to expire automatically
 3. guessing correct session ids
-   - problems: session data can leak
-   - possible mitigations:
-     - disable reading of data on the client side by disabling the api or
-       setting `api: { methods: [] }`
-     - increase the default sessionId length (although with `64` characters it
-       already is quite long, in 2022)
-     - use the `ipPinning` flag (although this means that everytime the user
-       changes IP address, they'll lose their current session)
+    - problems: session data can leak
+    - possible mitigations:
+        - disable reading of data on the client side by disabling the api or setting `api: { methods: [] }`
+        - increase the default sessionId length (although with `64` characters it already is quite long, in 2022)
+        - use the `ipPinning` flag (although this means that everytime the user changes IP address, they'll lose their current session)
 4. stealing session id(s) of client(s)
-   - problem: session data can leak
-   - possible mitigations:
-     - increase cookie protection, e.g., by setting
-       `session.cookieSameSite: 'strict'` (default: `lax`)
-     - use very short-lived sessions
-     - don't allow session renewal
+    - problem: session data can leak
+    - possible mitigations:
+        - increase cookie protection, e.g., by setting `session.cookieSameSite: 'strict'` (default: `lax`)
+        - use very short-lived sessions
+        - don't allow session renewal
 
-A last reminder: This library was not written by crypto- or security-experts. So
-please proceed at your own risk, inspect the code if you want to and open issues
-/ pull requests where you see room for improvement. If you want to file a
-security-concern privately, please send an email to `support@sidestream.tech`
-with the subject saying "SECURITY nuxt-session" and we'll look into your request
-ASAP.
+A last reminder: This library was not written by crypto- or security-experts. So please proceed at your own risk, inspect the code if you want to and open issues / pull requests where you see room for improvement. If you want to file a security-concern privately, please send an email to `support@sidestream.tech` with the subject saying "SECURITY nuxt-session" and we'll look into your request ASAP.
 
 ## Development
 
 - Run `npm run dev:prepare` to generate type stubs.
-- Use `npm run dev` to start [the module playground](./playground) in
-  development mode.
+- Use `npm run dev` to start [the module playground](./playground) in development mode.
 - Run `npm run lint` to run eslint
 - Run `npm run type` to run typescheck via tsc
 
-<!-- Badges -->
 
+
+<!-- Badges -->
 [npm-version-src]: https://img.shields.io/npm/v/@sidebase/nuxt-session/latest.svg
 [npm-version-href]: https://npmjs.com/package/@sidebase/nuxt-session
+
 [npm-downloads-src]: https://img.shields.io/npm/dt/@sidebase/nuxt-session.svg
 [npm-downloads-href]: https://npmjs.com/package/@sidebase/nuxt-session
+
 [license-src]: https://img.shields.io/npm/l/@sidebase/nuxt-session.svg
 [license-href]: https://npmjs.com/package/@sidebase/nuxt-session

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ Here's what the full _default_ module configuration looks like:
     // The session cookie same site policy is `lax`
     cookieSameSite: 'lax',
     // In-memory storage is used (these are `unjs/unstorage` options)
-    storageOptions: {}
+    storageOptions: {
+        driver: 'memory'
+    }
   },
   api: {
     // The API is enabled
@@ -229,6 +231,26 @@ Here's what the full _default_ module configuration looks like:
     basePath: '/api/session'
   }
 }
+```
+### Using a different storage driver
+
+You can use any stroage driver supported by unstorage. For example, this will use the redis driver instead of the default memory driver.
+```ts
+//nuxt.config.ts
+{
+    ...,
+    session: {
+        session:{
+            storageOptions:{
+                driver: 'redis',
+                options: {
+                    url: 'redis://localhost:6379'
+                }
+            }
+        }
+    }
+}
+
 ```
 
 ### Security 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -2,5 +2,18 @@ import { defineNuxtConfig } from 'nuxt/config'
 import NuxtSession from '../src/module'
 
 export default defineNuxtConfig({
-  modules: [NuxtSession]
+  modules: [NuxtSession],
+  session: {
+    session: {
+      // Redis
+      // storageOptions: {
+      //   driver: 'redis'
+      // }
+      // fs
+      // storageOptions: {
+      //   driver: 'fs',
+      //   base: './tmp'
+      // }
+    }
+  }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,15 +3,5 @@ import NuxtSession from '../src/module'
 
 export default defineNuxtConfig({
   modules: [NuxtSession],
-  session: {
-    session: {
-      // redis example configuration
-      // storageOptions: {
-      //   driver: 'redis',
-      //   options: {
-      //     url: 'redis://localhost:6379'
-      //   }
-      // }
-    }
-  }
+  session: {}
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -5,15 +5,6 @@ export default defineNuxtConfig({
   modules: [NuxtSession],
   session: {
     session: {
-      // Redis
-      // storageOptions: {
-      //   driver: 'redis'
-      // }
-      // fs
-      // storageOptions: {
-      //   driver: 'fs',
-      //   base: './tmp'
-      // }
     }
   }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -5,6 +5,13 @@ export default defineNuxtConfig({
   modules: [NuxtSession],
   session: {
     session: {
+      // redis example configuration
+      // storageOptions: {
+      //   driver: 'redis',
+      //   options: {
+      //     url: 'redis://localhost:6379'
+      //   }
+      // }
     }
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { addImportsDir, addServerHandler, defineNuxtModule, useLogger, addImports } from '@nuxt/kit'
+import { addImportsDir, addServerHandler, defineNuxtModule, useLogger } from '@nuxt/kit'
 import { defu } from 'defu'
 import { BuiltinDriverName, builtinDrivers } from 'unstorage'
 
@@ -128,7 +128,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults,
   hooks: {},
-  setup (moduleOptions, nuxt) {
+  setup(moduleOptions, nuxt) {
     const logger = useLogger(PACKAGE_NAME)
 
     // 1. Check if module should be enabled at all
@@ -144,9 +144,12 @@ export default defineNuxtModule<ModuleOptions>({
     options.api.methods = moduleOptions.api.methods.length > 0 ? moduleOptions.api.methods : ['patch', 'delete', 'get', 'post']
     nuxt.options.runtimeConfig.session = defu(nuxt.options.runtimeConfig.session, options)
     nuxt.options.runtimeConfig.public = defu(nuxt.options.runtimeConfig.public, { session: { api: options.api } })
-
     // setup unstorage
-    addImports([{ from: builtinDrivers[options.session.storageOptions.driver], name: 'default', as: 'sessionStorageDriver' }])
+    nuxt.options.nitro.virtual = defu(nuxt.options.nitro.virtual,
+      {
+        '#session-driver': `export { default } from '${builtinDrivers[options.session.storageOptions.driver]}'`,
+        '#session-config': `export default ${JSON.stringify(options)}`
+      })
     // 3. Locate runtime directory and transpile module
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -145,8 +145,7 @@ export default defineNuxtModule<ModuleOptions>({
     // setup unstorage
     nuxt.options.nitro.virtual = defu(nuxt.options.nitro.virtual,
       {
-        '#session-driver': `export { default } from '${builtinDrivers[options.session.storageOptions.driver]}'`,
-        '#session-config': `export default ${JSON.stringify(options)}`
+        '#session-driver': `export { default } from '${builtinDrivers[options.session.storageOptions.driver]}'`
       })
     // 3. Locate runtime directory and transpile module
     const { resolve } = createResolver(import.meta.url)
@@ -177,3 +176,8 @@ export default defineNuxtModule<ModuleOptions>({
     logger.success('Session setup complete')
   }
 })
+
+declare module '#session-driver'{
+  const driver : BuiltinDriverName
+  export default driver
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,7 @@ export type SupportedSessionApiMethods = 'patch' | 'delete' | 'get' | 'post'
 
 interface StorageConfig {
   driver: BuiltinDriverName,
-  [option: string]: any
+  options: object
 }
 
 declare interface SessionOptions {
@@ -107,7 +107,8 @@ const defaults: ModuleOptions = {
     storePrefix: 'sessions',
     cookieSameSite: 'lax',
     storageOptions: {
-      driver: 'memory'
+      driver: 'memory',
+      options: {}
     }
   },
   api: {
@@ -127,7 +128,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults,
   hooks: {},
-  setup (moduleOptions, nuxt) {
+  async setup (moduleOptions, nuxt) {
     const logger = useLogger(PACKAGE_NAME)
 
     // 1. Check if module should be enabled at all
@@ -144,10 +145,9 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.runtimeConfig.session = defu(nuxt.options.runtimeConfig.session, options)
     nuxt.options.runtimeConfig.public = defu(nuxt.options.runtimeConfig.public, { session: { api: options.api } })
 
-    //setup unstorage
-    const storage = setupStorage(options.session.storageOptions, options.session.storePrefix)
-    // const nitroStorageOptions = defu(nuxt.options.nitro.storage, { [options.session.storePrefix]: options.session.storageOptions })
-    // nuxt.options.nitro.storage = nitroStorageOptions
+    // setup unstorage
+    // TODO: provide this in a useSessionStorage() utility
+    const storage = await setupStorage(options.session.storageOptions, options.session.storePrefix)
 
     // 3. Locate runtime directory and transpile module
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))

--- a/src/module.ts
+++ b/src/module.ts
@@ -176,8 +176,3 @@ export default defineNuxtModule<ModuleOptions>({
     logger.success('Session setup complete')
   }
 })
-
-declare module '#session-driver'{
-  const driver : BuiltinDriverName
-  export default driver
-}

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,43 +12,43 @@ interface StorageConfig {
 }
 
 declare interface SessionOptions {
-  /**
+/**
    * Set the session duration in seconds. Once the session expires, a new one with a new id will be created. Set to `null` for infinite sessions
    * @default 600
    * @example 30
    * @type number | null
    */
   expiryInSeconds: number | null
-  /**
-   * How many characters the random session id should be long
-   * @default 64
-   * @example 128
-   * @type number
-   */
+   /**
+    * How many characters the random session id should be long
+    * @default 64
+    * @example 128
+    * @type number
+    */
   idLength: number
-  /**
-   * What prefix to use to store session information via `unstorage`
-   * @default "sessions"
-   * @example "userSessions"
-   * @type number
-   * @docs https://github.com/unjs/unstorage
-   */
-  storePrefix: string
-  /**
-   * When to attach session cookie to requests
-   * @default 'lax'
-   * @example 'strict'
-   * @type SameSiteOptions
-   * @docs https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
-   */
-  cookieSameSite: SameSiteOptions
-  /**
-   * Driver configuration for session-storage. Per default in-memory storage is used
-   * @default {}
-   * @example { driver: 'redis' }
-   * @docs https://nitro.unjs.io/guide/introduction/storage
-   */
-  storageOptions: StorageConfig,
+   /**
+    * What prefix to use to store session information via `unstorage`
+    * @default "sessions"
+    * @example "userSessions"
+    * @type number
+    * @docs https://github.com/unjs/unstorage
+    */
+   storePrefix: string
+   /**
+    * When to attach session cookie to requests
+    * @default 'lax'
+    * @example 'strict'
+    * @type SameSiteOptions
+    * @docs https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+    */
+   cookieSameSite: SameSiteOptions
+   /**
+    * Driver configuration for session-storage. Per default in-memory storage is used
+    * @default {}
+    * @example { driver: 'redis', options: {url: 'localhost:6379'} }
+    * @docs https://nitro.unjs.io/guide/introduction/storage
+    */
+   storageOptions: CreateStorageOptions,
 }
 
 declare interface ApiOptions {
@@ -58,22 +58,22 @@ declare interface ApiOptions {
    * @example false
    * @type boolean
    */
-  isEnabled: boolean
-  /**
-   * Configure which session API methods are enabled. All api methods are enabled by default. Restricting the enabled methods can be useful if you want to allow the client to read session-data but not modify it. Passing
-   * an empty array will result in all API methods being registered. Disable the api via the `api.isEnabled` option.
-   * @default []
-   * @example ['get']
-   * @type SupportedSessionApiMethods[]
-   */
-  methods: SupportedSessionApiMethods[]
-  /**
-   * Base path of the session api.
-   * @default /api/session
-   * @example /_session
-   * @type string
-   */
-  basePath: string
+   isEnabled: boolean
+   /**
+    * Configure which session API methods are enabled. All api methods are enabled by default. Restricting the enabled methods can be useful if you want to allow the client to read session-data but not modify it. Passing
+    * an empty array will result in all API methods being registered. Disable the api via the `api.isEnabled` option.
+    * @default []
+    * @example ['get']
+    * @type SupportedSessionApiMethods[]
+    */
+   methods: SupportedSessionApiMethods[]
+   /**
+    * Base path of the session api.
+    * @default /api/session
+    * @example /_session
+    * @type string
+    */
+   basePath: string
 }
 
 export interface ModuleOptions {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,23 @@
 import { addImportsDir, addServerHandler, createResolver, defineNuxtModule, useLogger } from '@nuxt/kit'
 import { defu } from 'defu'
 import { BuiltinDriverName, builtinDrivers } from 'unstorage'
+import type { FSStorageOptions } from 'unstorage/dist/drivers/fs'
+import type { KVOptions } from 'unstorage/dist/drivers/cloudflare-kv-binding'
+import type { KVHTTPOptions } from 'unstorage/dist/drivers/cloudflare-kv-http'
+import type { GithubOptions } from 'unstorage/dist/drivers/github'
+import type { HTTPOptions } from 'unstorage/dist/drivers/http'
+import type { OverlayStorageOptions } from 'unstorage/dist/drivers/overlay'
+import type { LocalStorageOptions } from 'unstorage/dist/drivers/localstorage'
+import type { RedisOptions } from 'unstorage/dist/drivers/redis'
+
+export type UnstorageDriverOption = FSStorageOptions | KVOptions | KVHTTPOptions | GithubOptions | HTTPOptions | OverlayStorageOptions | LocalStorageOptions | RedisOptions
 
 export type SameSiteOptions = 'lax' | 'strict' | 'none'
 export type SupportedSessionApiMethods = 'patch' | 'delete' | 'get' | 'post'
 
 interface StorageOptions {
   driver: BuiltinDriverName,
-  options: object
+  options?: UnstorageDriverOption
 }
 
 declare interface SessionOptions {
@@ -105,8 +115,7 @@ const defaults: ModuleOptions = {
     storePrefix: 'sessions',
     cookieSameSite: 'lax',
     storageOptions: {
-      driver: 'memory',
-      options: {}
+      driver: 'memory'
     }
   },
   api: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,12 +1,11 @@
 import { addImportsDir, addServerHandler, createResolver, defineNuxtModule, useLogger } from '@nuxt/kit'
-import { CreateStorageOptions } from 'unstorage'
 import { defu } from 'defu'
 import { BuiltinDriverName, builtinDrivers } from 'unstorage'
 
 export type SameSiteOptions = 'lax' | 'strict' | 'none'
 export type SupportedSessionApiMethods = 'patch' | 'delete' | 'get' | 'post'
 
-interface StorageConfig {
+interface StorageOptions {
   driver: BuiltinDriverName,
   options: object
 }
@@ -44,11 +43,11 @@ declare interface SessionOptions {
    cookieSameSite: SameSiteOptions
    /**
     * Driver configuration for session-storage. Per default in-memory storage is used
-    * @default {}
+    * @default { driver: 'memory', options: {} }
     * @example { driver: 'redis', options: {url: 'localhost:6379'} }
     * @docs https://nitro.unjs.io/guide/introduction/storage
     */
-   storageOptions: CreateStorageOptions,
+   storageOptions: StorageOptions,
 }
 
 declare interface ApiOptions {
@@ -127,7 +126,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults,
   hooks: {},
-  setup(moduleOptions, nuxt) {
+  setup (moduleOptions, nuxt) {
     const logger = useLogger(PACKAGE_NAME)
 
     // 1. Check if module should be enabled at all

--- a/src/module.ts
+++ b/src/module.ts
@@ -115,7 +115,8 @@ const defaults: ModuleOptions = {
     storePrefix: 'sessions',
     cookieSameSite: 'lax',
     storageOptions: {
-      driver: 'memory'
+      driver: 'memory',
+      options: {}
     }
   },
   api: {

--- a/src/runtime/server/middleware/session/sessionStorage.ts
+++ b/src/runtime/server/middleware/session/sessionStorage.ts
@@ -1,8 +1,8 @@
-import { createStorage } from 'unstorage'
+import { createStorage, prefixStorage } from 'unstorage'
+import { useRuntimeConfig } from '#imports'
 // @ts-ignore
 import sessionDriver from '#session-driver'
-import { useRuntimeConfig } from '#imports'
-const config = useRuntimeConfig()
-const sessionConfig = config.session
-const driver = sessionDriver(sessionConfig.session.storageOptions.options)
-export const sessionStorage = createStorage({ driver }).mount(sessionConfig.session.storePrefix, driver)
+const sessionConfig = useRuntimeConfig().session.session
+const driver = sessionDriver(sessionConfig.storageOptions.options)
+const storage = createStorage({ driver }).mount(sessionConfig.storePrefix, driver)
+export const sessionStorage = prefixStorage(storage, sessionConfig.storePrefix)

--- a/src/runtime/server/middleware/session/sessionStorage.ts
+++ b/src/runtime/server/middleware/session/sessionStorage.ts
@@ -1,5 +1,8 @@
 import { createStorage } from 'unstorage'
+// @ts-ignore
 import sessionDriver from '#session-driver'
-import sessionConfig from '#session-config'
+import { useRuntimeConfig } from '#imports'
+const config = useRuntimeConfig()
+const sessionConfig = config.session
 const driver = sessionDriver(sessionConfig.session.storageOptions.options)
 export const sessionStorage = createStorage({ driver }).mount(sessionConfig.session.storePrefix, driver)

--- a/src/runtime/server/middleware/session/sessionStorage.ts
+++ b/src/runtime/server/middleware/session/sessionStorage.ts
@@ -1,5 +1,5 @@
 import { createStorage } from 'unstorage'
 import sessionDriver from '#session-driver'
 import sessionConfig from '#session-config'
-
-export const sessionStorage = createStorage({ driver: sessionDriver() }).mount(sessionConfig.session.storePrefix, sessionDriver())
+const driver = sessionDriver(sessionConfig.session.storageOptions.options)
+export const sessionStorage = createStorage({ driver }).mount(sessionConfig.session.storePrefix, driver)

--- a/src/runtime/server/middleware/session/sessionStorage.ts
+++ b/src/runtime/server/middleware/session/sessionStorage.ts
@@ -1,0 +1,5 @@
+import { createStorage } from 'unstorage'
+import sessionDriver from '#session-driver'
+import sessionConfig from '#session-config'
+
+export const sessionStorage = createStorage({ driver: sessionDriver() }).mount(sessionConfig.session.storePrefix, sessionDriver())

--- a/src/runtime/server/middleware/session/storage.ts
+++ b/src/runtime/server/middleware/session/storage.ts
@@ -1,15 +1,8 @@
-import { createStorage, prefixStorage, StorageValue } from 'unstorage'
-import { useRuntimeConfig, sessionStorageDriver } from '#imports'
-
+import { prefixStorage, StorageValue } from 'unstorage'
+import { sessionStorage } from './sessionStorage'
+import { useRuntimeConfig } from '#imports'
 const sessionConfig = useRuntimeConfig().session.session
-const baseStorage = setupStorage(sessionConfig)
-const storage = prefixStorage(baseStorage, sessionConfig.storePrefix)
+const storage = prefixStorage(sessionStorage, sessionConfig.storePrefix)
 export const getStorageSession = (sessionId: string) => storage.getItem(sessionId)
 export const setStorageSession = (sessionId: string, session: StorageValue) => storage.setItem(sessionId, session)
 export const dropStorageSession = (sessionId: string) => storage.removeItem(sessionId)
-
-function setupStorage (storageConfig) {
-  const { options } = storageConfig
-  const storage = createStorage({ driver: sessionStorageDriver(options) })
-  return storage
-}

--- a/src/runtime/server/middleware/session/storage.ts
+++ b/src/runtime/server/middleware/session/storage.ts
@@ -1,8 +1,7 @@
-import { createStorage, prefixStorage, StorageValue } from 'unstorage'
-import { useRuntimeConfig } from '#imports'
-
-const storage = prefixStorage(createStorage(useRuntimeConfig().session.session.storageOptions), useRuntimeConfig().session.session.storePrefix)
-
+import { prefixStorage, StorageValue } from 'unstorage'
+import { useRuntimeConfig, useStorage } from '#imports'
+const baseStorage = useStorage()
+const storage = prefixStorage(baseStorage, useRuntimeConfig().session.session.storePrefix)
 export const getStorageSession = (sessionId: string) => storage.getItem(sessionId)
 export const setStorageSession = (sessionId: string, session: StorageValue) => storage.setItem(sessionId, session)
 export const dropStorageSession = (sessionId: string) => storage.removeItem(sessionId)

--- a/src/runtime/server/middleware/session/storage.ts
+++ b/src/runtime/server/middleware/session/storage.ts
@@ -1,8 +1,5 @@
-import { prefixStorage, StorageValue } from 'unstorage'
+import type { StorageValue } from 'unstorage'
 import { sessionStorage } from './sessionStorage'
-import { useRuntimeConfig } from '#imports'
-const sessionConfig = useRuntimeConfig().session.session
-const storage = prefixStorage(sessionStorage, sessionConfig.storePrefix)
-export const getStorageSession = (sessionId: string) => storage.getItem(sessionId)
-export const setStorageSession = (sessionId: string, session: StorageValue) => storage.setItem(sessionId, session)
-export const dropStorageSession = (sessionId: string) => storage.removeItem(sessionId)
+export const getStorageSession = (sessionId: string) => sessionStorage.getItem(sessionId)
+export const setStorageSession = (sessionId: string, session: StorageValue) => sessionStorage.setItem(sessionId, session)
+export const dropStorageSession = (sessionId: string) => sessionStorage.removeItem(sessionId)

--- a/src/runtime/server/middleware/session/storage.ts
+++ b/src/runtime/server/middleware/session/storage.ts
@@ -1,7 +1,15 @@
-import { prefixStorage, StorageValue } from 'unstorage'
-import { useRuntimeConfig, useStorage } from '#imports'
-const baseStorage = useStorage()
-const storage = prefixStorage(baseStorage, useRuntimeConfig().session.session.storePrefix)
+import { createStorage, prefixStorage, StorageValue } from 'unstorage'
+import { useRuntimeConfig, sessionStorageDriver } from '#imports'
+
+const sessionConfig = useRuntimeConfig().session.session
+const baseStorage = setupStorage(sessionConfig)
+const storage = prefixStorage(baseStorage, sessionConfig.storePrefix)
 export const getStorageSession = (sessionId: string) => storage.getItem(sessionId)
 export const setStorageSession = (sessionId: string, session: StorageValue) => storage.setItem(sessionId, session)
 export const dropStorageSession = (sessionId: string) => storage.removeItem(sessionId)
+
+function setupStorage (storageConfig) {
+  const { options } = storageConfig
+  const storage = createStorage({ driver: sessionStorageDriver(options) })
+  return storage
+}


### PR DESCRIPTION
Closes #8

Contributes to #26

Fixed by using Nitro's storage layer. The storageOptions were getting stored in the runtime config, but that looks like it does some kind of serializing. I had this config:
```js
session: {
    session: {
      cookieSameSite: 'strict',
      storageOptions: {
        driver: redisDriver({
          base: 'session:',
          url: process.env.REDIS_URL || 'redis://localhost:6379',
        }),
      },
    },
  },
  ```
  but was getting a " `fn` is not a function" error. 
  When I checked the storageOptions in `storage.ts`, the `driver` value was getting set to `{}`.
  
  So now the equivalent config would look like this:
  ```js
  session: {
    session: {
      storageOptions: {
        driver: 'redis',
        url: process.env.REDIS_URL || 'redis://localhost:6379'
      }
    }
  }
  ```
Also, in `storage.ts`, Typescript is yelling at me saying useStorage isn't exported from `'#imports'`. I'm not sure where that actually gets exported if not from there.