### PR TITLE
Add rolling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ Here's what the full _default_ module configuration looks like:
     // The request-domain is strictly used for the cookie, no sub-domains allowed
     domain: null,
     // Sessions aren't pinned to the user's IP address
-    ipPinning: false
+    ipPinning: false,
+    // Expiration of the sessions are not reset to the original expiryInSeconds on every request
+    rolling: false
   },
   api: {
     // The API is enabled

--- a/src/module.ts
+++ b/src/module.ts
@@ -23,7 +23,8 @@ const defaults: FilledModuleOptions = {
       options: {}
     },
     domain: null,
-    ipPinning: false as boolean|SessionIpPinningOptions
+    ipPinning: false as boolean|SessionIpPinningOptions,
+    rolling: false
   },
   api: {
     isEnabled: true,

--- a/src/runtime/server/middleware/session/index.ts
+++ b/src/runtime/server/middleware/session/index.ts
@@ -8,18 +8,26 @@ import { SessionExpired } from './exceptions'
 import { useRuntimeConfig } from '#imports'
 
 const SESSION_COOKIE_NAME = 'sessionId'
-const safeSetCookie = (event: H3Event, name: string, value: string) => setCookie(event, name, value, {
-  // Max age of cookie in seconds
-  maxAge: useRuntimeConfig().session.session.expiryInSeconds,
-  // Only send cookie via HTTPs to mitigate man-in-the-middle attacks
-  secure: true,
-  // Only send cookie via HTTP requests, do not allow access of cookie from JS to mitigate XSS attacks
-  httpOnly: true,
-  // Do not send cookies on many cross-site requests to mitigates CSRF and cross-site attacks, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#lax
-  sameSite: useRuntimeConfig().session.session.cookieSameSite as SameSiteOptions,
-  // Set cookie for subdomain
-  domain: useRuntimeConfig().session.session.domain
-})
+const safeSetCookie = (event: H3Event, name: string, value: string, date: Date) => {
+  const sessionConfig = useRuntimeConfig().session.session
+  const expirationDate = sessionConfig.expiryInSeconds ? date : undefined
+  if (expirationDate) {
+    expirationDate.setSeconds(expirationDate.getSeconds() + sessionConfig.expiryInSeconds)
+  }
+
+  setCookie(event, name, value, {
+    // Set cookie expiration date to now + expiryInSeconds
+    expires: expirationDate,
+    // Only send cookie via HTTPs to mitigate man-in-the-middle attacks
+    secure: true,
+    // Only send cookie via HTTP requests, do not allow access of cookie from JS to mitigate XSS attacks
+    httpOnly: true,
+    // Do not send cookies on many cross-site requests to mitigates CSRF and cross-site attacks, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#lax
+    sameSite: sessionConfig.cookieSameSite as SameSiteOptions,
+    // Set cookie for subdomain
+    domain: sessionConfig.domain
+  })
+}
 
 const checkSessionExpirationTime = (session: Session, sessionExpiryInSeconds: number) => {
   const now = dayjs()
@@ -61,15 +69,16 @@ export const deleteSession = async (event: H3Event) => {
 const newSession = async (event: H3Event) => {
   const runtimeConfig = useRuntimeConfig()
   const sessionOptions = runtimeConfig.session.session
+  const now = new Date()
 
   // (Re-)Set cookie
   const sessionId = nanoid(sessionOptions.idLength)
-  safeSetCookie(event, SESSION_COOKIE_NAME, sessionId)
+  safeSetCookie(event, SESSION_COOKIE_NAME, sessionId, now)
 
   // Store session data in storage
   const session: Session = {
     id: sessionId,
-    createdAt: new Date(),
+    createdAt: now,
     ip: sessionOptions.ipPinning ? await getHashedIpAddress(event) : undefined
   }
   await setStorageSession(sessionId, session)
@@ -113,14 +122,24 @@ const getSession = async (event: H3Event): Promise<null | Session> => {
   return session
 }
 
+const touchSession = (session: Session, event: H3Event) => {
+  const now = new Date()
+  session.createdAt = now
+  safeSetCookie(event, SESSION_COOKIE_NAME, session.id, now)
+}
+
 function isSession (shape: unknown): shape is Session {
   return typeof shape === 'object' && !!shape && 'id' in shape && 'createdAt' in shape
 }
 
 const ensureSession = async (event: H3Event) => {
+  const sessionConfig = useRuntimeConfig().session.session
+
   let session = await getSession(event)
   if (!session) {
     session = await newSession(event)
+  } else if (sessionConfig.rolling) {
+    touchSession(session, event)
   }
 
   event.context.sessionId = session.id

--- a/src/runtime/server/middleware/session/index.ts
+++ b/src/runtime/server/middleware/session/index.ts
@@ -9,9 +9,9 @@ import { useRuntimeConfig } from '#imports'
 
 const SESSION_COOKIE_NAME = 'sessionId'
 const safeSetCookie = (event: H3Event, name: string, value: string, createdAt: Date) => {
-  const sessionConfig = useRuntimeConfig().session.session
-  const expirationDate = sessionConfig.expiryInSeconds
-    ? new Date(createdAt.getTime() + sessionConfig.expiryInSeconds * 1000)
+  const sessionOptions = useRuntimeConfig().session.session as SessionOptions
+  const expirationDate = sessionOptions.expiryInSeconds
+    ? new Date(createdAt.getTime() + sessionOptions.expiryInSeconds * 1000)
     : undefined
 
   setCookie(event, name, value, {
@@ -22,9 +22,9 @@ const safeSetCookie = (event: H3Event, name: string, value: string, createdAt: D
     // Only send cookie via HTTP requests, do not allow access of cookie from JS to mitigate XSS attacks
     httpOnly: true,
     // Do not send cookies on many cross-site requests to mitigates CSRF and cross-site attacks, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#lax
-    sameSite: sessionConfig.cookieSameSite as SameSiteOptions,
+    sameSite: sessionOptions.cookieSameSite as SameSiteOptions,
     // Set cookie for subdomain
-    domain: sessionConfig.domain
+    domain: sessionOptions.domain || undefined
   })
 }
 
@@ -67,7 +67,7 @@ export const deleteSession = async (event: H3Event) => {
 
 const newSession = async (event: H3Event) => {
   const runtimeConfig = useRuntimeConfig()
-  const sessionOptions = runtimeConfig.session.session
+  const sessionOptions = runtimeConfig.session.session as SessionOptions
   const now = new Date()
 
   // (Re-)Set cookie
@@ -132,12 +132,12 @@ function isSession (shape: unknown): shape is Session {
 }
 
 const ensureSession = async (event: H3Event) => {
-  const sessionConfig = useRuntimeConfig().session.session
+  const sessionOptions = useRuntimeConfig().session.session as SessionOptions
 
   let session = await getSession(event)
   if (!session) {
     session = await newSession(event)
-  } else if (sessionConfig.rolling) {
+  } else if (sessionOptions.rolling) {
     session = updateSessionExpirationDate(session, event)
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,13 @@ export interface SessionOptions {
    * @type {SessionIpPinningOptions|boolean}
    */
   ipPinning: SessionIpPinningOptions|boolean,
+  /**
+   * Force the session identifier cookie to be set on every response. The expiration is reset to the original expiryInSeconds, resetting the expiration countdown.
+   * @default false
+   * @example true
+   * @type boolean
+   */
+  rolling: boolean
 }
 
 export interface ApiOptions {


### PR DESCRIPTION
Add rolling as an option to be able to force the session identifier cookie to be set on every response. The expiration is reset to the original `expiryInSeconds`, resetting the expiration countdown.

This is typically used in conjuction with short `expiryInSeconds` values to provide a quick timeout of the session data with reduced potential of it occurring during on going server interactions.

This should behave similar to the rolling option in `express-session` middleware.

To implement this, it was necessary to set the `expires` property of the cookie instead of `maxAge`, which doesn't affect the current behavior of the middleware.