### PR TITLE
Fix `expiryInSeconds = null` has no effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Here's what the full _default_ module configuration looks like:
         options: {}
     },
     // The request-domain is strictly used for the cookie, no sub-domains allowed
-    domain: null,
+    domain: false,
     // Sessions aren't pinned to the user's IP address
     ipPinning: false
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,7 +24,7 @@ const defaults: FilledModuleOptions = {
       driver: 'memory',
       options: {}
     },
-    domain: null,
+    domain: false,
     ipPinning: false as boolean|SessionIpPinningOptions,
     rolling: false
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,7 +24,7 @@ const defaults: FilledModuleOptions = {
       driver: 'memory',
       options: {}
     },
-    domain: null,
+    domain: false,
     ipPinning: false as boolean|SessionIpPinningOptions
   },
   api: {

--- a/src/runtime/server/middleware/session/index.ts
+++ b/src/runtime/server/middleware/session/index.ts
@@ -10,7 +10,7 @@ import { useRuntimeConfig } from '#imports'
 const SESSION_COOKIE_NAME = 'sessionId'
 const safeSetCookie = (event: H3Event, name: string, value: string, createdAt: Date) => {
   const sessionOptions = useRuntimeConfig().session.session as SessionOptions
-  const expirationDate = sessionOptions.expiryInSeconds
+  const expirationDate = sessionOptions.expiryInSeconds !== false
     ? new Date(createdAt.getTime() + sessionOptions.expiryInSeconds * 1000)
     : undefined
 

--- a/src/runtime/server/middleware/session/index.ts
+++ b/src/runtime/server/middleware/session/index.ts
@@ -10,7 +10,7 @@ import { useRuntimeConfig } from '#imports'
 const SESSION_COOKIE_NAME = 'sessionId'
 const safeSetCookie = (event: H3Event, name: string, value: string) => setCookie(event, name, value, {
   // Max age of cookie in seconds
-  maxAge: useRuntimeConfig().session.session.expiryInSeconds,
+  maxAge: useRuntimeConfig().session.session.expiryInSeconds || undefined,
   // Wether to send cookie via HTTPs to mitigate man-in-the-middle attacks
   secure: useRuntimeConfig().session.session.cookieSecure,
   // Wether to send cookie via HTTP requests and not allowing access of cookie from JS to mitigate XSS attacks
@@ -18,7 +18,7 @@ const safeSetCookie = (event: H3Event, name: string, value: string) => setCookie
   // Do not send cookies on many cross-site requests to mitigates CSRF and cross-site attacks, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#lax
   sameSite: useRuntimeConfig().session.session.cookieSameSite as SameSiteOptions,
   // Set cookie for subdomain
-  domain: useRuntimeConfig().session.session.domain
+  domain: useRuntimeConfig().session.session.domain || undefined
 })
 
 const checkSessionExpirationTime = (session: Session, sessionExpiryInSeconds: number) => {
@@ -96,7 +96,7 @@ const getSession = async (event: H3Event): Promise<null | Session> => {
 
   try {
     // 3. Is the session not expired?
-    if (sessionExpiryInSeconds !== null) {
+    if (sessionExpiryInSeconds) {
       checkSessionExpirationTime(session, sessionExpiryInSeconds)
     }
 

--- a/src/runtime/server/middleware/session/index.ts
+++ b/src/runtime/server/middleware/session/index.ts
@@ -104,7 +104,7 @@ const getSession = async (event: H3Event): Promise<null | Session> => {
 
   try {
     // 3. Is the session not expired?
-    if (sessionExpiryInSeconds) {
+    if (sessionExpiryInSeconds !== false) {
       checkSessionExpirationTime(session, sessionExpiryInSeconds)
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,12 +28,12 @@ export interface SessionIpPinningOptions {
 
 export interface SessionOptions {
   /**
-   * Set the session duration in seconds. Once the session expires, a new one with a new id will be created. Set to `null` for infinite sessions
+   * Set the session duration in seconds. Once the session expires, a new one with a new id will be created. Set to `false` for infinite sessions
    * @default 600
    * @example 30
-   * @type number | null
+   * @type number | false
    */
-  expiryInSeconds: number | null
+  expiryInSeconds: number | false
   /**
    * How many characters the random session id should be long
    * @default 64
@@ -81,13 +81,13 @@ export interface SessionOptions {
    */
   storageOptions: StorageOptions,
   /**
-   * Set the domain the session cookie will be receivable by. Setting `domain: null` results in setting the domain the cookie is initially set on. Specifying a domain will allow the domain and all its sub-domains.
-   * @default null
+   * Set the domain the session cookie will be receivable by. Setting `domain: false` results in setting the domain the cookie is initially set on. Specifying a domain will allow the domain and all its sub-domains.
+   * @default false
    * @example '.example.com'
-   * @type string | null
+   * @type string | false
    * @docs https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
    */
-  domain: string | null,
+  domain: string | false,
   /**
    * Whether to pin sessions to the user's IP (i.e. Different IP means a different session)
    * @default false


### PR DESCRIPTION
Closes #38.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable

Properties with null values aren't copied by `defu`.
As mentioned [here](https://github.com/unjs/defu/issues/12), we would need to exchange `defu` with another module which doesn't ignore null, or change the `expiryInSeconds` option to use false instead of null.

I also changed the `domain` property type, as it is also affected, but currently doesn't make any problems, because null is the default value here.
