### PR TITLE
Make mandatory session properties immutable

### DIFF
--- a/src/runtime/server/middleware/session/index.ts
+++ b/src/runtime/server/middleware/session/index.ts
@@ -113,6 +113,24 @@ const getSession = async (event: H3Event): Promise<null | Session> => {
   return session
 }
 
+const getImmutableSession = (session: Session) => {
+  const immutableSession = { ...session }
+
+  Object.defineProperty(immutableSession, 'id', {
+    writable: false
+  })
+
+  Object.defineProperty(immutableSession, 'createdAt', {
+    writable: false
+  })
+
+  Object.defineProperty(immutableSession, 'ip', {
+    writable: false
+  })
+
+  return immutableSession as Session
+}
+
 function isSession (shape: unknown): shape is Session {
   return typeof shape === 'object' && !!shape && 'id' in shape && 'createdAt' in shape
 }
@@ -124,7 +142,7 @@ const ensureSession = async (event: H3Event) => {
   }
 
   event.context.sessionId = session.id
-  event.context.session = session
+  event.context.session = getImmutableSession(session)
   return session
 }
 


### PR DESCRIPTION
Closes #2.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable

Attach a session object to the event context with mandatory immutable properties `id`, `createdAt` and `ip`.
When the user wants to reassign those properties, an error is thrown. This is better than just doing nothing, because the user knows that he did something wrong in saving properties to the session in the event context. 