### PR TITLE
chore: Add deprication notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**DEPRECATION NOTICE:** `nuxt-session` will be depreacated at the 11.12.2023 - read https://github.com/sidebase/nuxt-session/issues/91 for reasoning and process.
+
 ![logo of nuxt session](./.github/session.png)
 
 # nuxt-session

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**DEPRECATION NOTICE:** `nuxt-session` will be depreacated at the 11.12.2023 - read https://github.com/sidebase/nuxt-session/issues/91 for reasoning and process.
+**DEPRECATION NOTICE:** `nuxt-session` will be depreacated at the 11.12.2023 - read https://github.com/sidebase/nuxt-session/issues/91 for reasoning and process. We recommend migrating to [`h3` sessions](https://github.com/unjs/h3#session) for your applications.
 
 ![logo of nuxt session](./.github/session.png)
 


### PR DESCRIPTION
contributes to #91

Informs users that we will depricate `nuxt-session` on the 11.12.2023.